### PR TITLE
[style/responsive-temp-homeandsidebar] 💄 style:반응형 디자인 수정 및 로그인상태 연결

### DIFF
--- a/src/common/NearbyAnimals.tsx
+++ b/src/common/NearbyAnimals.tsx
@@ -1,3 +1,119 @@
+// import like from "../assets/icons/like.svg";
+
+// export interface AnimalProps {
+//   id: number;
+//   imageUrl?: string;
+//   name: string;
+//   providerShelterName?: string;
+//   neuteredStatus?: string;
+//   characteristics?: string[];
+// }
+
+// // 기존 “년생” 파싱 로직 재활용
+// const getAgeFromName = (name: string): string | null => {
+//   const currentYear = new Date().getFullYear();
+//   const regex = /(\d{4})(?:\([^)]*\))*\(년생\)/;
+//   const match = name.match(regex);
+//   if (match && match[1]) {
+//     const birthYear = parseInt(match[1], 10);
+//     const age = currentYear - birthYear;
+//     return `${age}살`;
+//   }
+//   return null;
+// };
+
+// export default function NearbyAnimals({
+//   id,
+//   imageUrl,
+//   name,
+//   providerShelterName,
+//   neuteredStatus,
+//   characteristics = [],
+// }: AnimalProps) {
+//   //이름에서 나이 추출
+//   const age = getAgeFromName(name);
+
+//   //"YYYY(...)(년생)" 부분을 제거해 "실제 품종/이름"만 남김
+//   const cleanedName = name.replace(/\s*\d{4}(?:\([^)]*\))*\(년생\)/, "");
+
+//   //characteristics에서 성별 추출 ("남"/"여"가 들어 있으면 M/F로)
+//   let sexCd: "M" | "F" | undefined;
+//   if (characteristics.includes("남")) {
+//     sexCd = "M";
+//   } else if (characteristics.includes("여")) {
+//     sexCd = "F";
+//   }
+
+//   // characteristics에서 "Kg"가 들어간 문자열을 찾으면 체중으로 사용
+//   const weight = characteristics.find((item) => item.includes("Kg"));
+
+//   return (
+//     <div
+//       // key={id}는 보통 부모(map) 쪽에서 설정하지만
+//       // 여기서도 혹시나 필요하면 둘 수 있음
+//       className="
+//         w-full
+//         min-w-[150px]
+//         max-w-[320px]
+//         bg-white
+//         rounded-lg
+//         shadow-md
+//         flex
+//         flex-col
+//         transition-all
+//         duration-200
+//         hover:shadow-lg
+//       "
+//     >
+//       {/* 16:9 비율 이미지 영역 */}
+//       <div className="w-full aspect-video rounded-t-lg overflow-hidden">
+//         <img
+//           src={imageUrl ?? "https://via.placeholder.com/150"}
+//           alt={cleanedName}
+//           className="w-full h-full object-cover"
+//           loading="lazy"
+//         />
+//       </div>
+
+//       {/* 내용 영역 */}
+//       <div className="p-3 sm:p-4 flex flex-col justify-between flex-1">
+//         <div>
+//           <span className="block font-semibold text-sm sm:text-base mt-1 sm:mt-2">
+//             {cleanedName}
+//             {sexCd === "M" && " (남아)"}
+//             {sexCd === "F" && " (여아)"}
+//           </span>
+
+//           <span className="block font-medium text-xs sm:text-sm text-gray-500 mt-1 sm:mt-2">
+//             {providerShelterName ?? "보호소 정보 없음"}
+//           </span>
+//         </div>
+
+//         <div className="flex items-center justify-between mt-2">
+//           <div className="flex flex-wrap gap-1 sm:gap-2">
+//             {neuteredStatus && (
+//               <span className="bg-gray-100 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-xs text-gray-500">
+//                 {neuteredStatus === "Y" ? "중성화 완료" : "중성화 안됨"}
+//               </span>
+//             )}
+//             {weight && (
+//               <span className="bg-gray-100 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-xs text-gray-500">
+//                 {weight}
+//               </span>
+//             )}
+//             {age && (
+//               <span className="bg-gray-100 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-xs text-gray-500">
+//                 {age}
+//               </span>
+//             )}
+//           </div>
+//           <img src={like} alt="좋아요" className="w-4 h-4 flex-shrink-0" />
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
 import like from "../assets/icons/like.svg";
 
 export interface AnimalProps {
@@ -30,31 +146,37 @@ export default function NearbyAnimals({
   neuteredStatus,
   characteristics = [],
 }: AnimalProps) {
-  //이름에서 나이 추출
+  // 이름에서 나이 추출
   const age = getAgeFromName(name);
 
-  //"YYYY(...)(년생)" 부분을 제거해 "실제 품종/이름"만 남김
-  const cleanedName = name.replace(/\s*\d{4}(?:\([^)]*\))*\(년생\)/, "");
+  // "YYYY(...)(년생)" 부분을 제거해 실제 이름만 남기고 양쪽 공백 제거
+  const cleanedName = name.replace(/\s*\d{4}(?:\([^)]*\))*\(년생\)/, "").trim();
 
-  //characteristics에서 성별 추출 ("남"/"여"가 들어 있으면 M/F로)
-  let sexCd: "M" | "F" | undefined;
-  if (characteristics.includes("남")) {
-    sexCd = "M";
+  // cleanedName에 이미 성별 표시가 포함되어 있는지 확인
+  const genderAlreadyDisplayed =
+    cleanedName.includes("(남아)") ||
+    cleanedName.includes("(여아)") ||
+    cleanedName.includes("(성별 미상)");
+
+  // characteristics에서 성별 정보 결정
+  let genderDisplay = "";
+  if (characteristics.includes("(성별 미상)")) {
+    genderDisplay = " (성별 미상)";
+  } else if (characteristics.includes("남")) {
+    genderDisplay = " (남아)";
   } else if (characteristics.includes("여")) {
-    sexCd = "F";
+    genderDisplay = " (여아)";
   }
 
-  // characteristics에서 "Kg"가 들어간 문자열을 찾으면 체중으로 사용
+  // characteristics에서 "Kg"가 들어간 문자열을 찾아 체중으로 사용
   const weight = characteristics.find((item) => item.includes("Kg"));
 
   return (
     <div
-      // key={id}는 보통 부모(map) 쪽에서 설정하지만
-      // 여기서도 혹시나 필요하면 둘 수 있음
       className="
         w-full
-        min-w-[150px]
-        max-w-[320px]
+        min-w-[150px] sm:min-w-[200px] md:min-w-[250px] lg:min-w-[300px]
+        lg:max-w-[300px]
         bg-white
         rounded-lg
         shadow-md
@@ -80,10 +202,8 @@ export default function NearbyAnimals({
         <div>
           <span className="block font-semibold text-sm sm:text-base mt-1 sm:mt-2">
             {cleanedName}
-            {sexCd === "M" && " (남아)"}
-            {sexCd === "F" && " (여아)"}
+            {!genderAlreadyDisplayed && genderDisplay}
           </span>
-
           <span className="block font-medium text-xs sm:text-sm text-gray-500 mt-1 sm:mt-2">
             {providerShelterName ?? "보호소 정보 없음"}
           </span>
@@ -92,17 +212,17 @@ export default function NearbyAnimals({
         <div className="flex items-center justify-between mt-2">
           <div className="flex flex-wrap gap-1 sm:gap-2">
             {neuteredStatus && (
-              <span className="bg-gray-100 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-xs text-gray-500">
+              <span className="whitespace-nowrap bg-gray-100 px-1 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-[0.65rem] sm:text-xs text-gray-500">
                 {neuteredStatus === "Y" ? "중성화 완료" : "중성화 안됨"}
               </span>
             )}
             {weight && (
-              <span className="bg-gray-100 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-xs text-gray-500">
+              <span className="hidden sm:inline whitespace-nowrap bg-gray-100 px-1 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-[0.65rem] sm:text-xs text-gray-500">
                 {weight}
               </span>
             )}
             {age && (
-              <span className="bg-gray-100 px-1.5 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-xs text-gray-500">
+              <span className="whitespace-nowrap bg-gray-100 px-1 py-0.5 sm:px-2 sm:py-1 rounded font-semibold text-[0.65rem] sm:text-xs text-gray-500">
                 {age}
               </span>
             )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import SidebarM from "./SidebarM";
 import ButtonComponent from "../../common/ButtonComponent";
 import logo from "../../assets/icons/logo.svg";
+import SidebarM from "./SidebarM";
 import LoginModal from "./LoginModal";
 import { useAuthStore } from "../../store/authStore";
 
@@ -13,6 +13,21 @@ export default function Header() {
   // Zustand 스토어에서 로그인 상태와 액션, 사용자 정보 가져오기
   const { isLoggedIn, userInfo, logout, resetState } = useAuthStore();
   const navigate = useNavigate();
+
+  //SidebarM에서 발생한 커스텀 이벤트 리스닝
+  useEffect(() => {
+    const handleOpenLoginModal = () => {
+      setIsModalOpen(true);
+    };
+
+    // 이벤트 리스너 등록
+    window.addEventListener("openLoginModal", handleOpenLoginModal);
+
+    // 컴포넌트 언마운트 시 이벤트 리스너 제거
+    return () => {
+      window.removeEventListener("openLoginModal", handleOpenLoginModal);
+    };
+  }, []);
 
   // 로그아웃 버튼 클릭 시
   const handleLogout = async () => {

--- a/src/components/layout/LoginModal.tsx
+++ b/src/components/layout/LoginModal.tsx
@@ -7,7 +7,7 @@ interface LoginModalProps {
   onClose: () => void;
 }
 
-const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
+export default function LoginModal({ isOpen, onClose }: LoginModalProps) {
   const {
     isLoading,
     error,
@@ -24,6 +24,13 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
     }
   }, [isOpen, handleOAuthCallback]);
 
+  // 로그인 성공 시 모달 닫기
+  useEffect(() => {
+    if (isLoggedIn && userInfo) {
+      onClose();
+    }
+  }, [isLoggedIn, userInfo, onClose]);
+
   // 모달 밖 영역 클릭 시 닫기
   const handleBackgroundClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
@@ -35,46 +42,48 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50"
+      className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50 p-4"
       onClick={handleBackgroundClick}
     >
-      <div className="bg-white rounded-3xl shadow-lg w-[476px] min-h-[438px] flex flex-col justify-between p-10">
+      <div className="bg-white rounded-3xl shadow-lg w-full max-w-lg flex flex-col justify-between p-5 sm:p-8 md:p-10">
         <div className="text-center">
-          <p className="flex items-center justify-center mb-8 text-[18px] font-semibold">
+          <p className="flex items-center justify-center mb-6 sm:mb-8 text-base sm:text-lg font-semibold">
             <img src={logo} alt="logo" className="pr-2" />
             PAWEVER
           </p>
-          <p className="text-[28px] font-bold mb-4">로그인</p>
-          <p className="text-[24px] text-gray-500 mb-4 font-semibold leading-[1.2]">
+          <p className="text-xl sm:text-2xl md:text-3xl font-bold mb-3 sm:mb-4">
+            로그인
+          </p>
+          <p className="text-lg sm:text-xl md:text-2xl text-gray-500 mb-3 sm:mb-4 font-semibold leading-snug">
             작은 발자국이
             <br />
             영원한 가족을 만듭니다
           </p>
-          <p className="text-md text-gray-500 mb-9">
+          <p className="text-sm md:text-base text-gray-500 mb-6 sm:mb-9">
             PAWEVER에 로그인하고 가족을 찾아보세요!
           </p>
         </div>
 
         {/* 에러 메시지 */}
         {error && (
-          <div className="mb-4 p-2 bg-red-100 text-red-800 rounded text-sm">
+          <div className="mb-4 p-2 bg-red-100 text-red-800 rounded text-xs sm:text-sm">
             {error}
           </div>
         )}
 
         {/* 로그인 성공 여부 */}
         {isLoggedIn && userInfo && (
-          <div className="mb-4 p-2 bg-green-100 text-green-800 rounded text-sm">
+          <div className="mb-4 p-2 bg-green-100 text-green-800 rounded text-xs sm:text-sm">
             환영합니다, {userInfo.name}님!
           </div>
         )}
 
-        <div className="flex flex-col items-center justify-center gap-3">
+        <div className="flex flex-col items-center justify-center gap-4 w-full">
           {/* Google 로그인 버튼 */}
           <button
             onClick={googleLoginInit}
             disabled={isLoading}
-            className="w-[380px] h-[48px] bg-white text-gray-700 py-2 rounded-md border border-solid hover:bg-gray-50 disabled:opacity-70 flex items-center justify-center"
+            className="w-full h-12 bg-white text-gray-700 py-2 rounded-md border border-solid hover:bg-gray-50 disabled:opacity-70 flex items-center justify-center"
           >
             {isLoading ? (
               <span className="mr-2 h-4 w-4 border-2 border-gray-400 border-t-transparent rounded-full animate-spin"></span>
@@ -105,7 +114,7 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
           <button
             onClick={kakaoLoginInit}
             disabled={isLoading}
-            className="w-[380px] h-[48px] bg-yellow-400 text-black py-2 rounded-md hover:bg-yellow-500 flex items-center justify-center disabled:opacity-70"
+            className="w-full h-12 bg-yellow-400 text-black py-2 rounded-md hover:bg-yellow-500 flex items-center justify-center disabled:opacity-70"
           >
             {isLoading ? (
               <span className="mr-2 h-4 w-4 border-2 border-black border-t-transparent rounded-full animate-spin"></span>
@@ -128,6 +137,4 @@ const LoginModal: React.FC<LoginModalProps> = ({ isOpen, onClose }) => {
       </div>
     </div>
   );
-};
-
-export default LoginModal;
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,114 +1,219 @@
-import { useState, useEffect } from "react";
+// import { useState } from "react";
+// import { useAuthStore } from "../../store/authStore";
+// import HeroSection from "./components/HeroSection";
+// import FilterSection from "./components/FilterSection";
+// import CardSection from "./components/CardSection";
+// import useNearbyAnimals from "../../hooks/useNearbyAnimals";
+// import useProtectedAnimals from "../../hooks/useProtectedAnimals";
+
+// export default function Home() {
+//   const [fetchAllowed, setFetchAllowed] = useState(false);
+
+//   const { userInfo } = useAuthStore();
+//   const userName = userInfo?.name || "게스트";
+//   const {
+//     data: protectedData,
+//     isLoading: isProtectedLoading,
+//     isError: isProtectedError,
+//   } = useProtectedAnimals({}, 4);
+
+//   // 근처 동물 데이터 (강아지+고양이 병합)
+//   const { data: nearbyAnimals, isError: isNearbyError } =
+//     useNearbyAnimals(fetchAllowed);
+//   return (
+//     <div className="flex flex-col justify-center">
+//       <HeroSection />
+//       <FilterSection />
+//       {/* 보호중인 동물 섹션 */}
+//       <CardSection
+//         title="보호중인 동물"
+//         cards={20}
+//         protectedAnimals={protectedData?.animals}
+//         isProtectedLoading={isProtectedLoading}
+//         isProtectedError={isProtectedError}
+//       />
+//       <div className="mt-8">
+//         {/* 근처 동물 섹션 */}
+//         <CardSection
+//           title={`${userName}님 근처의 동물`}
+//           cards={10}
+//           animals={nearbyAnimals}
+//           isError={isNearbyError}
+//           fetchAllowed={fetchAllowed}
+//           onSearch={() => setFetchAllowed(true)}
+//         />
+//       </div>
+//     </div>
+//   );
+// }
+
+//체크중
+
+// import { useState, useEffect } from "react";
+// import HeroSection from "./components/HeroSection";
+// import FilterSection from "./components/FilterSection";
+// import CardSection from "./components/CardSection";
+// import useNearbyAnimals from "../../hooks/useNearbyAnimals";
+// import useProtectedAnimals from "../../hooks/useProtectedAnimals";
+// import { useAuthStore } from "../../store/authStore";
+// import toast from "react-hot-toast";
+
+// export default function Home() {
+//   const [fetchAllowed, setFetchAllowed] = useState(false);
+//   const [location, setLocation] = useState<{ lat: number; lng: number } | null>(
+//     null
+//   );
+
+//   // useAuthStore에서 사용자 정보 가져오기
+//   const { userInfo } = useAuthStore();
+
+//   // 사용자 이름 표시를 위한 변수 - 사용자 정보가 없으면 '게스트'로 표시
+//   const userName = userInfo?.name || "게스트";
+
+//   // 보호중인 동물 데이터 - 4페이지 데이터 가져오기 (총 20마리)
+//   const {
+//     data: protectedData,
+//     isLoading: isProtectedLoading,
+//     isError: isProtectedError,
+//   } = useProtectedAnimals({}, 4);
+
+//   // 근처 동물 데이터 (강아지+고양이 병합) - 위치 정보 전달
+//   const {
+//     data: nearbyAnimals,
+//     isLoading: isNearbyLoading,
+//     isError: isNearbyError,
+//     error: nearbyError,
+//   } = useNearbyAnimals(fetchAllowed);
+
+//   // 에러 메시지 확인 및 표시
+//   useEffect(() => {
+//     if (isNearbyError && nearbyError) {
+//       toast.error(`근처 동물 데이터 로딩 오류: ${nearbyError.message}`);
+//       console.error("근처 동물 데이터 오류:", nearbyError);
+//     }
+//   }, [isNearbyError, nearbyError]);
+
+//   // 사용자 위치 정보 가져오기
+//   const getUserLocation = () => {
+//     if (!navigator.geolocation) {
+//       toast.error("브라우저가 위치 정보를 지원하지 않습니다.");
+//       return;
+//     }
+
+//     const loadingToast = toast.loading("위치 정보를 가져오는 중...");
+
+//     navigator.geolocation.getCurrentPosition(
+//       // 성공 콜백
+//       (position) => {
+//         const { latitude, longitude } = position.coords;
+
+//         // 위치 정보를 상태에 저장하고 콘솔에 로그 출력
+//         console.log("위치 정보 획득 성공:", { latitude, longitude });
+//         setLocation({ lat: latitude, lng: longitude });
+//         setFetchAllowed(true);
+
+//         toast.dismiss(loadingToast);
+//         toast.success("위치 정보를 성공적으로 가져왔습니다!");
+//       },
+//       // 실패 콜백
+//       (error) => {
+//         toast.dismiss(loadingToast);
+
+//         let errorMessage = "위치 정보를 가져오는 데 실패했습니다.";
+//         switch (error.code) {
+//           case error.PERMISSION_DENIED:
+//             errorMessage = "위치 정보 접근 권한이 거부되었습니다.";
+//             break;
+//           case error.POSITION_UNAVAILABLE:
+//             errorMessage = "위치 정보를 사용할 수 없습니다.";
+//             break;
+//           case error.TIMEOUT:
+//             errorMessage = "위치 정보 요청 시간이 초과되었습니다.";
+//             break;
+//         }
+
+//         console.error("위치 정보 획득 실패:", errorMessage, error);
+//         toast.error(errorMessage);
+//       },
+//       {
+//         enableHighAccuracy: true,
+//         timeout: 10000,
+//         maximumAge: 0,
+//       }
+//     );
+//   };
+
+//   // 동물찾기 버튼 클릭 핸들러
+//   const handleSearchClick = () => {
+//     getUserLocation();
+//   };
+
+//   // 에러 처리
+//   useEffect(() => {
+//     if (isProtectedError) {
+//       toast.error("보호중인 동물 데이터를 불러오는 중 오류가 발생했습니다.");
+//     }
+//   }, [isProtectedError]);
+
+//   return (
+//     <div className="flex flex-col justify-center">
+//       <HeroSection />
+//       <FilterSection />
+
+//       {/* 보호중인 동물 섹션 */}
+//       <CardSection
+//         title="보호중인 동물"
+//         cards={20}
+//         protectedAnimals={protectedData?.animals}
+//         isProtectedLoading={isProtectedLoading}
+//         isProtectedError={isProtectedError}
+//       />
+
+//       <div className="mt-8">
+//         {/* 근처 동물 섹션 - 동적 사용자 이름 적용 */}
+//         <CardSection
+//           title={`${userName}님 근처의 동물`}
+//           cards={10}
+//           animals={nearbyAnimals}
+//           isLoading={isNearbyLoading}
+//           isError={isNearbyError}
+//           fetchAllowed={fetchAllowed}
+//           onSearch={handleSearchClick}
+//         />
+//       </div>
+//     </div>
+//   );
+// }
+
+//반응형디자인
+
+import { useState } from "react";
+import { useAuthStore } from "../../store/authStore";
 import HeroSection from "./components/HeroSection";
 import FilterSection from "./components/FilterSection";
 import CardSection from "./components/CardSection";
 import useNearbyAnimals from "../../hooks/useNearbyAnimals";
 import useProtectedAnimals from "../../hooks/useProtectedAnimals";
-import { useAuthStore } from "../../store/authStore";
-import toast from "react-hot-toast";
 
 export default function Home() {
   const [fetchAllowed, setFetchAllowed] = useState(false);
-  const [location, setLocation] = useState<{ lat: number; lng: number } | null>(
-    null
-  );
 
-  // useAuthStore에서 사용자 정보 가져오기
   const { userInfo } = useAuthStore();
-
-  // 사용자 이름 표시를 위한 변수 - 사용자 정보가 없으면 '게스트'로 표시
   const userName = userInfo?.name || "게스트";
-
-  // 보호중인 동물 데이터 - 4페이지 데이터 가져오기 (총 20마리)
   const {
     data: protectedData,
     isLoading: isProtectedLoading,
     isError: isProtectedError,
   } = useProtectedAnimals({}, 4);
 
-  // 근처 동물 데이터 (강아지+고양이 병합) - 위치 정보 전달
-  const {
-    data: nearbyAnimals,
-    isLoading: isNearbyLoading,
-    isError: isNearbyError,
-    error: nearbyError,
-  } = useNearbyAnimals(fetchAllowed);
-
-  // 에러 메시지 확인 및 표시
-  useEffect(() => {
-    if (isNearbyError && nearbyError) {
-      toast.error(`근처 동물 데이터 로딩 오류: ${nearbyError.message}`);
-      console.error("근처 동물 데이터 오류:", nearbyError);
-    }
-  }, [isNearbyError, nearbyError]);
-
-  // 사용자 위치 정보 가져오기
-  const getUserLocation = () => {
-    if (!navigator.geolocation) {
-      toast.error("브라우저가 위치 정보를 지원하지 않습니다.");
-      return;
-    }
-
-    const loadingToast = toast.loading("위치 정보를 가져오는 중...");
-
-    navigator.geolocation.getCurrentPosition(
-      // 성공 콜백
-      (position) => {
-        const { latitude, longitude } = position.coords;
-
-        // 위치 정보를 상태에 저장하고 콘솔에 로그 출력
-        console.log("위치 정보 획득 성공:", { latitude, longitude });
-        setLocation({ lat: latitude, lng: longitude });
-        setFetchAllowed(true);
-
-        toast.dismiss(loadingToast);
-        toast.success("위치 정보를 성공적으로 가져왔습니다!");
-      },
-      // 실패 콜백
-      (error) => {
-        toast.dismiss(loadingToast);
-
-        let errorMessage = "위치 정보를 가져오는 데 실패했습니다.";
-        switch (error.code) {
-          case error.PERMISSION_DENIED:
-            errorMessage = "위치 정보 접근 권한이 거부되었습니다.";
-            break;
-          case error.POSITION_UNAVAILABLE:
-            errorMessage = "위치 정보를 사용할 수 없습니다.";
-            break;
-          case error.TIMEOUT:
-            errorMessage = "위치 정보 요청 시간이 초과되었습니다.";
-            break;
-        }
-
-        console.error("위치 정보 획득 실패:", errorMessage, error);
-        toast.error(errorMessage);
-      },
-      {
-        enableHighAccuracy: true,
-        timeout: 10000,
-        maximumAge: 0,
-      }
-    );
-  };
-
-  // 동물찾기 버튼 클릭 핸들러
-  const handleSearchClick = () => {
-    getUserLocation();
-  };
-
-  // 에러 처리
-  useEffect(() => {
-    if (isProtectedError) {
-      toast.error("보호중인 동물 데이터를 불러오는 중 오류가 발생했습니다.");
-    }
-  }, [isProtectedError]);
+  // 근처 동물 데이터 (강아지+고양이 병합)
+  const { data: nearbyAnimals, isError: isNearbyError } =
+    useNearbyAnimals(fetchAllowed);
 
   return (
-    <div className="flex flex-col justify-center">
+    <div className="max-w-screen-xl mx-auto px-4 flex flex-col gap-8 overflow-x-hidden">
       <HeroSection />
       <FilterSection />
-
       {/* 보호중인 동물 섹션 */}
       <CardSection
         title="보호중인 동물"
@@ -117,19 +222,15 @@ export default function Home() {
         isProtectedLoading={isProtectedLoading}
         isProtectedError={isProtectedError}
       />
-
-      <div className="mt-8">
-        {/* 근처 동물 섹션 - 동적 사용자 이름 적용 */}
-        <CardSection
-          title={`${userName}님 근처의 동물`}
-          cards={10}
-          animals={nearbyAnimals}
-          isLoading={isNearbyLoading}
-          isError={isNearbyError}
-          fetchAllowed={fetchAllowed}
-          onSearch={handleSearchClick}
-        />
-      </div>
+      {/* 근처 동물 섹션 */}
+      <CardSection
+        title={`${userName}님 근처의 동물`}
+        cards={10}
+        animals={nearbyAnimals}
+        isError={isNearbyError}
+        fetchAllowed={fetchAllowed}
+        onSearch={() => setFetchAllowed(true)}
+      />
     </div>
   );
 }

--- a/src/pages/home/components/CardSection.tsx
+++ b/src/pages/home/components/CardSection.tsx
@@ -1,3 +1,163 @@
+// import { useRef } from "react";
+// import { Link } from "react-router-dom";
+// import { Animal } from "../../../hooks/useProtectedAnimals";
+// import NearbyAnimals from "../../../common/NearbyAnimals";
+
+// interface CardSectionProps {
+//   title: string;
+//   cards: number;
+
+//   // 보호중인 동물 섹션 props
+//   protectedAnimals?: Animal[];
+//   isProtectedLoading?: boolean;
+//   isProtectedError?: boolean;
+
+//   // "User님 근처의 동물" 섹션 props
+//   animals?: any[]; // 받아온 동물 배열 (강아지+고양이 병합 데이터)
+//   isLoading?: boolean;
+//   isError?: boolean;
+//   fetchAllowed?: boolean; // 현재 API 호출이 되었는지 여부
+//   onSearch?: () => void; // 버튼 클릭 시 실행할 함수
+// }
+
+// export default function CardSection({
+//   title,
+//   cards,
+//   protectedAnimals,
+//   isProtectedLoading,
+//   isProtectedError,
+//   animals,
+//   isLoading,
+//   isError,
+//   fetchAllowed,
+//   onSearch,
+// }: CardSectionProps) {
+//   const containerRef = useRef<HTMLDivElement | null>(null);
+
+//   const scroll = (direction: "left" | "right") => {
+//     if (containerRef.current && containerRef.current.firstElementChild) {
+//       const cardWidth = containerRef.current.firstElementChild.clientWidth;
+//       containerRef.current.scrollBy({
+//         left: direction === "left" ? -cardWidth : cardWidth,
+//         behavior: "smooth",
+//       });
+//     }
+//   };
+
+//   return (
+//     <div>
+//       {/* 상단 헤더 영역 */}
+//       <div className="flex items-center justify-between mb-4 pl-1 max-w-[1200px] mx-auto">
+//         <div className="flex items-center gap-2">
+//           <p className="font-semibold text-[1.375rem]">{title}</p>
+//           {/* "동물찾기" 버튼 - onSearch가 있으면 표시 */}
+//           {onSearch && (
+//             <button
+//               onClick={onSearch}
+//               className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
+//             >
+//               동물찾기
+//             </button>
+//           )}
+//         </div>
+
+//         <div className="flex items-center">
+//           <p className="font-semibold text-base text-gray-400">전체보기</p>
+//           <div className="flex items-center ml-2 w-[61px] h-[28px] rounded-lg border border-gray-300">
+//             <button
+//               onClick={() => scroll("left")}
+//               className="w-1/2 h-full text-gray-300 flex items-center justify-center"
+//             >
+//               <span className="text-[1.125rem]">&lt;</span>
+//             </button>
+//             <div className="w-[1px] h-full bg-gray-300" />
+//             <button
+//               onClick={() => scroll("right")}
+//               className="w-1/2 h-full text-gray-300 flex items-center justify-center"
+//             >
+//               <span className="text-[1.125rem]">&gt;</span>
+//             </button>
+//           </div>
+//         </div>
+//       </div>
+
+//       {/* 가로 스크롤 영역 */}
+//       <div className="w-full overflow-x-auto">
+//         <div
+//           ref={containerRef}
+//           className="flex space-x-4 overflow-x-auto scrollbar-hide snap-x snap-mandatory pb-4"
+//           style={{
+//             scrollbarWidth: "none",
+//             msOverflowStyle: "none",
+//             WebkitOverflowScrolling: "touch",
+//           }}
+//         >
+//           {/* 보호중인 동물 섹션 */}
+//           {protectedAnimals !== undefined ? (
+//             isProtectedLoading ? (
+//               <p className="pl-1">보호중인 동물 정보를 불러오는 중...</p>
+//             ) : isProtectedError ? (
+//               <p className="pl-1">
+//                 데이터를 가져오는 도중 오류가 발생했습니다.
+//               </p>
+//             ) : protectedAnimals.length > 0 ? (
+//               // API에서 가져온 보호중인 동물 데이터 표시
+//               protectedAnimals.slice(0, cards).map((animal, index) => (
+//                 <div
+//                   key={animal.id}
+//                   className="flex-none pl-1 snap-start w-[calc(50%-0.5rem)] sm:w-auto sm:min-w-[150px] sm:max-w-[256px]"
+//                 >
+//                   <Link to={`/AnimalBoard/${animal.id}`}>
+//                     <NearbyAnimals
+//                       id={animal.id}
+//                       imageUrl={animal.imageUrl}
+//                       name={animal.name}
+//                       providerShelterName={animal.providerShelterName}
+//                       neuteredStatus={animal.neuteredStatus}
+//                       characteristics={animal.characteristics}
+//                     />
+//                   </Link>
+//                 </div>
+//               ))
+//             ) : (
+//               <p className="pl-1">보호중인 동물이 없습니다.</p>
+//             )
+//           ) : !fetchAllowed ? (
+//             // "User님 근처의 동물" 섹션이고 버튼 클릭 전
+//             <p className="pl-1">버튼을 눌러 내 근처 동물을 찾아보세요!</p>
+//           ) : isLoading ? (
+//             <p className="pl-1">불러오는 중...</p>
+//           ) : isError ? (
+//             <p className="pl-1">데이터를 가져오는 도중 오류가 발생했습니다.</p>
+//           ) : animals && animals.length > 0 ? (
+//             // 주변 동물 데이터 (강아지+고양이 병합 데이터)
+//             animals.slice(0, cards).map((animal, index) => (
+//               <div
+//                 key={animal.id || index}
+//                 className="flex-none pl-1 snap-start w-[calc(50%-0.5rem)] sm:w-auto sm:min-w-[150px] sm:max-w-[256px]"
+//               >
+//                 <Link to={`/AnimalBoard/${animal.id}`}>
+//                   <NearbyAnimals
+//                     id={animal.id}
+//                     imageUrl={animal.imageUrl}
+//                     name={animal.name || "이름 없음"}
+//                     providerShelterName={animal.providerShelterName}
+//                     neuteredStatus={animal.neuteredStatus}
+//                     characteristics={animal.characteristics || []}
+//                   />
+//                 </Link>
+//               </div>
+//             ))
+//           ) : (
+//             // fetchAllowed=true지만, 빈 배열
+//             <p className="pl-1">근처에 보호 중인 동물이 없습니다.</p>
+//           )}
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
 import { useRef } from "react";
 import { Link } from "react-router-dom";
 import { Animal } from "../../../hooks/useProtectedAnimals";
@@ -49,8 +209,8 @@ export default function CardSection({
       {/* 상단 헤더 영역 */}
       <div className="flex items-center justify-between mb-4 pl-1 max-w-[1200px] mx-auto">
         <div className="flex items-center gap-2">
-          <p className="font-semibold text-[1.375rem]">{title}</p>
-          {/* "동물찾기" 버튼 - onSearch가 있으면 표시 */}
+          {/* 모바일에서는 text-lg, md 이상에서는 text-[1.375rem] 적용 */}
+          <p className="font-semibold text-lg md:text-[1.375rem]">{title}</p>
           {onSearch && (
             <button
               onClick={onSearch}
@@ -92,7 +252,6 @@ export default function CardSection({
             WebkitOverflowScrolling: "touch",
           }}
         >
-          {/* 보호중인 동물 섹션 */}
           {protectedAnimals !== undefined ? (
             isProtectedLoading ? (
               <p className="pl-1">보호중인 동물 정보를 불러오는 중...</p>
@@ -101,11 +260,10 @@ export default function CardSection({
                 데이터를 가져오는 도중 오류가 발생했습니다.
               </p>
             ) : protectedAnimals.length > 0 ? (
-              // API에서 가져온 보호중인 동물 데이터 표시
-              protectedAnimals.slice(0, cards).map((animal, index) => (
+              protectedAnimals.slice(0, cards).map((animal) => (
                 <div
                   key={animal.id}
-                  className="flex-none pl-1 snap-start w-[calc(50%-0.5rem)] sm:w-auto sm:min-w-[150px] sm:max-w-[256px]"
+                  className="flex-none snap-start w-[45%] sm:min-w-[200px] md:min-w-[250px] lg:min-w-[300px] lg:max-w-[300px]"
                 >
                   <Link to={`/AnimalBoard/${animal.id}`}>
                     <NearbyAnimals
@@ -123,18 +281,16 @@ export default function CardSection({
               <p className="pl-1">보호중인 동물이 없습니다.</p>
             )
           ) : !fetchAllowed ? (
-            // "User님 근처의 동물" 섹션이고 버튼 클릭 전
             <p className="pl-1">버튼을 눌러 내 근처 동물을 찾아보세요!</p>
           ) : isLoading ? (
             <p className="pl-1">불러오는 중...</p>
           ) : isError ? (
             <p className="pl-1">데이터를 가져오는 도중 오류가 발생했습니다.</p>
           ) : animals && animals.length > 0 ? (
-            // 주변 동물 데이터 (강아지+고양이 병합 데이터)
             animals.slice(0, cards).map((animal, index) => (
               <div
                 key={animal.id || index}
-                className="flex-none pl-1 snap-start w-[calc(50%-0.5rem)] sm:w-auto sm:min-w-[150px] sm:max-w-[256px]"
+                className="flex-none snap-start w-[45%] sm:min-w-[200px] md:min-w-[250px] lg:min-w-[300px] lg:max-w-[300px]"
               >
                 <Link to={`/AnimalBoard/${animal.id}`}>
                   <NearbyAnimals
@@ -149,7 +305,6 @@ export default function CardSection({
               </div>
             ))
           ) : (
-            // fetchAllowed=true지만, 빈 배열
             <p className="pl-1">근처에 보호 중인 동물이 없습니다.</p>
           )}
         </div>

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -319,6 +319,7 @@ function cleanupUrlParams() {
   window.history.replaceState({}, document.title, url.toString());
 }
 
+//위치정보 받아오기 전
 /* 구글 사용자 정보 호출*/
 async function fetchGoogleUserInfo(code: string): Promise<UserInfo | null> {
   try {
@@ -435,8 +436,8 @@ async function fetchKakaoUserInfo(code: string): Promise<UserInfo | null> {
       profileImageUrl: user.picture || "",
       email: user.email,
       socialLoginProvider: "kakao",
-      latitude: "0",
-      longitude: "0",
+      latitude: "37.6336457",
+      longitude: "126.7927116",
     };
     const jwtData = await requestJwtFromBackend(payload);
     if (!jwtData.isSuccess) return null;


### PR DESCRIPTION
## ✨ 반영 브랜치

`style/responsive-temp-homeandsidebar` -> `dev`

## 📝 설명 & 변경사항

Home 컴포넌트의 디자인을 반응형으로 수정하였습니다. (1차수정 입니다!)
Sidebar에서 로그인상태를 확인가능합니다.
로그인 & 로그아웃 상태관리를 통일했습니다. (SidebarM과 LoginModal 상태통합)
로그인 버튼을 누르면 작은 로그인 모달창이 나와서 소셜로그인을 유도합니다.


## 💬 PR 포인트 & 질문사항

아직 완전히 구현된 것은 아니지만 **주석처리된 부분은 백업본이라서 신경안쓰셔도 됩니다**

"근처의 동물" 부분은 아직 어떻게 UI처리를 해야할지 몰라서 깨지는게 맞습니다~ 추후에 다른 방식으로 의논한 다음에 다시 수정할 계획입니다. 


## 📷 변경사항 스크린샷

![image](https://github.com/user-attachments/assets/b523af9b-ff34-4c03-9d28-dd69a8d03a18)
![image](https://github.com/user-attachments/assets/6cf684c6-c919-416c-b9a3-a0e18b0ae147)



## 📢 이슈 정보


